### PR TITLE
Make async methods really async

### DIFF
--- a/src/Platformus.Barebone.Backend/Areas/Backend/ViewComponents/BackendMenuViewComponent.cs
+++ b/src/Platformus.Barebone.Backend/Areas/Backend/ViewComponents/BackendMenuViewComponent.cs
@@ -1,23 +1,34 @@
 ﻿// Copyright © 2015 Dmitry Sikorsky. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Threading.Tasks;
 using ExtCore.Data.Abstractions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Platformus.Barebone.Backend.ViewModels.Shared;
 
 namespace Platformus.Barebone.Backend.ViewComponents
 {
   public class BackendMenuViewComponent : ViewComponentBase
   {
-    public BackendMenuViewComponent(IStorage storage)
+      private ILoggerFactory _loggerFactory;
+    public BackendMenuViewComponent(IStorage storage, ILoggerFactory loggerFactory)
       : base(storage)
     {
+        _loggerFactory = loggerFactory;
     }
 
     public async Task<IViewComponentResult> InvokeAsync()
     {
-      return this.View(new BackendMenuViewModelFactory(this).Create());
+        BackendMenuViewModelFactory factory = new BackendMenuViewModelFactory(this);
+
+        Stopwatch watch = new Stopwatch();
+        watch.Start();
+        BackendMenuViewModel menu = await factory.CreateAsync();
+        watch.Stop();
+        _loggerFactory.CreateLogger<BackendMenuViewComponent>().LogInformation("Time to build menu content by BackendMenuViewModelFactory: " + watch.ElapsedMilliseconds + " ms");
+        return View(menu);
     }
   }
 }


### PR DESCRIPTION
Hi Dmitry,

My IDE showed a warning for [use of async keyword without await](https://github.com/Platformus/Platformus/blob/master/src/Platformus.Barebone.Backend/Areas/Backend/ViewComponents/BackendMenuViewComponent.cs#L18). So I started learning and made the backend menu content (items) be really returned asynchronously by the factory.

Please can you test my code changes? I was indeed too lazy to install Platformus. You see the same work on my [own web application](https://github.com/OSAMES/Base) that needs few configuration before being launched (see readme).

In my case, I have two extensions, each that provides a single menu item to the same single menu group.
Sync code takes 5 ms while async code takes 6 ms. The overhead seems not that excessive to keep the async code until the global time reaches 50 ms.

I'm very interested in your performance measures with Platformus, and how many menu groups and menu items you have, it will be more significative than on my project.

Thanks for the exchange.