### PR TITLE
Resolves: Add GitHub Codespaces configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0.201.9-5.0
+
+# Install Mono
+RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+	sudo dpkg -i packages-microsoft-prod.deb && \
+	sudo apt-get update && \
+	sudo apt-get install -y apt-transport-https && \
+	sudo apt-get update && \
+	sudo apt-get install -y dotnet-sdk-2.1
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+	"name": "Platformus Codespace",
+	"settings": {
+		"workbench.colorTheme": "Default Dark+",
+		"terminal.integrated.defaultProfile.linux": "pwsh"
+	},
+	"extensions": [
+		// VS Code specific
+		"coenraads.bracket-pair-colorizer",
+		"vscode-icons-team.vscode-icons",
+		"editorconfig.editorconfig",
+		// GitHub specific
+		"eamodio.gitlens",
+		"cschleiden.vscode-github-actions",
+		"redhat.vscode-yaml",
+		"bierner.markdown-preview-github-styles",
+		"ban.spellright",
+		// .NET specific
+		"ms-dotnettools.csharp",
+		"VisualStudioExptTeam.vscodeintellicode",
+		"ms-vscode.powershell",
+		"jmrog.vscode-nuget-package-manager",
+		// JS/TS specific
+		"dbaeumer.vscode-eslint",
+		"ms-vscode.vscode-typescript-next",
+		"ecmel.vscode-html-css",
+	],
+	"postCreateCommand": "",
+	"build": {
+		"dockerfile": "Dockerfile"
+	}
+}
+
+// Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)


### PR DESCRIPTION
- ready-to-start GitHub Codespaces configuration with all necessary tooling

- in addition, it provides basic tools for:
  - .NET development
  - JS development
  - GitHub support
  - overall more pleasant VS Code experience
  
The configuration consists of:

- `"settings":` - a list of VS Code settings to be applied automatically after the Codespace container is created (.editorconfig overrides these)
  - `"workbench.colorTheme": "Default Dark+"` - sets the theme of the VS Code workbench to the `Default Dark+` theme
  - `"terminal.integrated.defaultProfile.linux": "pwsh"` - sets the default VS Code terminal to PowerShell Core

- `extensions:` - a list of VS Code extensions that are automatically installed after the Codespace container is created
  - `"coenraads.bracket-pair-colorizer"` - sets different colors for each nested pair of brackets
  - `"vscode-icons-team.vscode-icons"` - provides a huge set of icons for the VS Code explorer
  - `"editorconfig.editorconfig"` - attempts to override user/workspace settings with those in the .editorconfig
  - `"eamodio.gitlens"` - provides git information directly inside the code
  - `"cschleiden.vscode-github-actions"` and `"redhat.vscode-yaml"` - provide YAML and GitHub Actions support
  - `"bierner.markdown-preview-github-styles"` and `"ban.spellright"` - provide assistance with writing Markdown documentation
  - `"ms-dotnettools.csharp"` and `"VisualStudioExptTeam.vscodeintellicode"` - provide basic Visual Studio tooling
  - `"ms-vscode.powershell"` - provides the functionality of Windows PowerShell ISE inside VS Code
  - `"jmrog.vscode-nuget-package-manager"` - provides use of the NuGet library through the Command Palette
  - `"dbaeumer.vscode-eslint"` - most popular linter for JS
  - `"ms-vscode.vscode-typescript-next"` - JS and TS intellisense support
  - `"ecmel.vscode-html-css"` - HTML `id` and `class` attribute completion
  
- `"postCreateCommand"` - is a string of commands separated by `&&` that execute after the container has been built and the source code has been cloned

- `"build"` - declares the Docker configuration that the container would use to run.

- `Dockerfile`:
  - `"mcr.microsoft.com/vscode/devcontainers/dotnet:0.201.9-5.0"` - the Codespace container runs from an Ubuntu 20.04 image with .NET Core SDK installed (`0.201.9` is the latest .NET Core SDK Docker image tagged version)
  - Additional installed tools:
    - .NET Core SDK 2.1 - required by some of the unit tests

This GitHub Codespace configuration can also be used locally with the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension for VS Code. It automatically creates and runs a Docker container based on the `devcontainer.json` configuration inside the repo, so anyone could work on the project from any computer, without the need to install anything other than VS Code and Docker.

Resolves #232 