### PR TITLE
Bump NuGet package versions to compatible maximum

### DIFF
--- a/src/Platformus.Core.Data.EntityFramework.SqlServer/Platformus.Core.Data.EntityFramework.SqlServer.csproj
+++ b/src/Platformus.Core.Data.EntityFramework.SqlServer/Platformus.Core.Data.EntityFramework.SqlServer.csproj
@@ -9,7 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="ExtCore.Data.EntityFramework.SqlServer" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.84.0" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platformus.Core/Platformus.Core.csproj
+++ b/src/Platformus.Core/Platformus.Core.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="ExtCore.Events" Version="9.0.0" />
     <PackageReference Include="ExtCore.Mvc" Version="9.0.0" />
     <PackageReference Include="Magicalizer.Data.Repositories.Abstractions" Version="4.0.0" />
-    <PackageReference Include="MailKit" Version="4.6.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platformus.Images/Platformus.Images.csproj
+++ b/src/Platformus.Images/Platformus.Images.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platformus.WebApplication/Platformus.WebApplication.csproj
+++ b/src/Platformus.WebApplication/Platformus.WebApplication.csproj
@@ -9,10 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="ExtCore.Data" Version="9.0.0" />
     <PackageReference Include="ExtCore.Data.EntityFramework" Version="9.0.0" />
     <PackageReference Include="ExtCore.WebApplication" Version="9.0.0" />
     <PackageReference Include="Magicalizer.Data.Repositories.EntityFramework" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.84.0" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platformus.Website.Data.EntityFramework.SqlServer/Platformus.Website.Data.EntityFramework.SqlServer.csproj
+++ b/src/Platformus.Website.Data.EntityFramework.SqlServer/Platformus.Website.Data.EntityFramework.SqlServer.csproj
@@ -9,7 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="ExtCore.Data.EntityFramework.SqlServer" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.84.0" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bump NuGet package versions to compatible maximum, including vulnerable transitive packages.

MailKit: 4.6.0 -> 4.16.0
Newtonsotf.Json: 13.0.3 -> 13.0.4
SixLabors.ImageSharp: 3.1.4 -> 3.1.12
Azure.Identity: transitive vulnerable version -> 1.21.0
Microsoft.Extensions.Caching.Memory: transitive vulnerable version -> 10.0.8 
Microsoft.Idemtity.Client: transitive vulnerable version -> 4.84.0
System.Linq.Dynamic.Core: transitive vulnerable version -> 1.7.2